### PR TITLE
Add requirements.txt for easier development

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyQT5
+polling2


### PR DESCRIPTION
This PR adds a requirements.txt file so that pip -r requirements.txt works to pre-load Python modules.