### PR TITLE
Build apps using actions

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -1,0 +1,70 @@
+# This workflow file generates binaries for both Windows
+# and OS X.  However, https://github.com/actions/upload-artifact/issues/38
+# that basically says that it won't ever preserve permissions.
+# That means an archive in an archive since we need to preserve them
+# on OS X.  Still... better than doing this all by hand.
+
+---
+
+name: pyinstaller
+
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+jobs:
+  pyinstaller-mac:
+    runs-on: macos-10.15
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: install dependencies
+        run: |
+          python3 -m venv /tmp/venv
+          source /tmp/venv/bin/activate
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: pyinstaller
+        run: |
+          cd Serato-Now-Playing
+          cp resources/SeratoNowPlaying_MAC.spec SeratoNowPlaying_MAC.spec
+          /tmp/venv/bin/pyinstaller -w SeratoNowPlaying_MAC.spec
+      - name: manipulate the dist
+        run: |
+          pwd
+          cd Serato-Now-Playing/dist
+          zip -r SeratoNowPlaying.zip SeratoNowPlaying.app
+          rm -rf SeratoNowPlaying SeratoNowPlaying.app
+      - name: artifact dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac-dist
+          path: Serato-Now-Playing/dist/
+
+  pyinstaller-win:
+    runs-on: windows-2019
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: stuff
+        run: pwd
+      - name: pyinstaller
+        run: |
+          cd Serato-Now-Playing
+          COPY resources\\SeratoNowPlaying_WIN.spec SeratoNowPlaying_WIN.spec
+          pyinstaller -F -w SeratoNowPlaying_WIN.spec
+      - name: artifact dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: win-dist
+          path: Serato-Now-Playing\\dist\\SeratoNowPlaying.exe

--- a/Serato-Now-Playing/resources/SeratoNowPlaying_MAC.spec
+++ b/Serato-Now-Playing/resources/SeratoNowPlaying_MAC.spec
@@ -4,9 +4,10 @@ block_cipher = None
 
 
 a = Analysis(['SeratoNowPlaying.py'],
-             pathex=['/Users/miranda/Documents/GitHub/Now-Playing-Serato/Serato-Now-Playing'],
+             pathex=['/Users/runner/work/Now-Playing-Serato/Now-Playing-Serato'],
              binaries=[],
-             datas=[('bin/icon.ico', './bin')],
+             datas=[('bin/icon.ico', './bin'),
+                    ('bin/config.ini', './bin')],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],
@@ -38,7 +39,7 @@ coll = COLLECT(exe,
 app = BUNDLE(coll,
              name='SeratoNowPlaying.app',
              icon='resources/seratoPlaying.icns',
-             bundle_identifier=None, 
+             bundle_identifier=None,
              info_plist={
                 'LSUIElement': True
              })

--- a/Serato-Now-Playing/resources/SeratoNowPlaying_WIN.spec
+++ b/Serato-Now-Playing/resources/SeratoNowPlaying_WIN.spec
@@ -4,7 +4,7 @@ block_cipher = None
 
 
 a = Analysis(['SeratoNowPlaying.py'],
-             pathex=['C:\\Users\\Ely Miranda\\OneDrive\\Documents\\SeratoNowPlaying\\dev\\working'],
+             pathex=['C:\\Users\\runner\\work\\Now-Playing-Serato\\Now-Playing-Serato'],
              binaries=[],
              datas=[],
              hiddenimports=[],
@@ -30,4 +30,4 @@ exe = EXE(pyz,
           upx=True,
           upx_exclude=[],
           runtime_tmpdir=None,
-          console=False , icon='seratoPlaying.ico')
+          console=False , icon='resources\\seratoPlaying.ico')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-PyQT5
+cryptography
+lxml
 polling2
+pyinstaller
+PyQT5
+requests
+urllib3


### PR DESCRIPTION
* Add a github action that runs pyinstaller on the
  source for every push and PR
* update requirements.txt to have a few more things
  in it
* add the missing config.ini in the Mac spec file
* change the default paths in the spec files to match
  github

NOTE: The OS X build is doubly-archived because Github
      upload-artifacts is strips permissions. :(